### PR TITLE
Highlight rust macros

### DIFF
--- a/Catppuccin Frappe.sublime-color-scheme
+++ b/Catppuccin Frappe.sublime-color-scheme
@@ -427,6 +427,12 @@
             "font_style": ""
         },
         {
+            "name": "Rust macro",
+            "scope": "support.macro.rust",
+            "foreground": "var(sky)",
+            "font_style": "italic",
+        },
+        {
             "name": "Invalid",
             "scope": "invalid",
             "foreground": "var(text)",

--- a/Catppuccin Latte.sublime-color-scheme
+++ b/Catppuccin Latte.sublime-color-scheme
@@ -427,6 +427,12 @@
             "font_style": ""
         },
         {
+            "name": "Rust macro",
+            "scope": "support.macro.rust",
+            "foreground": "var(sky)",
+            "font_style": "italic",
+        },
+        {
             "name": "Invalid",
             "scope": "invalid",
             "foreground": "var(text)",

--- a/Catppuccin Macchiato.sublime-color-scheme
+++ b/Catppuccin Macchiato.sublime-color-scheme
@@ -427,6 +427,12 @@
             "font_style": ""
         },
         {
+            "name": "Rust macro",
+            "scope": "support.macro.rust",
+            "foreground": "var(sky)",
+            "font_style": "italic",
+        },
+        {
             "name": "Invalid",
             "scope": "invalid",
             "foreground": "var(text)",

--- a/Catppuccin Mocha.sublime-color-scheme
+++ b/Catppuccin Mocha.sublime-color-scheme
@@ -427,6 +427,12 @@
             "font_style": ""
         },
         {
+            "name": "Rust macro",
+            "scope": "support.macro.rust",
+            "foreground": "var(sky)",
+            "font_style": "italic",
+        },
+        {
             "name": "Invalid",
             "scope": "invalid",
             "foreground": "var(text)",


### PR DESCRIPTION
Macros in the Rust Enhanced syntax plugin are not highlighted. 
before:
![image](https://user-images.githubusercontent.com/7707250/235545312-8aa2ffa5-a622-48ce-8e21-f65108dc2cfb.png)
after:
![image](https://user-images.githubusercontent.com/7707250/235545320-af40f3a1-12af-475d-a073-0cf8fc77f8b0.png)
I used the colors from https://github.com/catppuccin/ksyntaxhighlighting/blob/3f7bc6ddaa9c77608fd85e734c86d220c6a785ea/catppuccin-latte.theme#L843

The default Rust syntax does not define a name/scope for macros so this does not affect it