### PR TITLE
Add color to Ruby symbols

### DIFF
--- a/Catppuccin Frappe.sublime-color-scheme
+++ b/Catppuccin Frappe.sublime-color-scheme
@@ -104,6 +104,11 @@
             "scope": "variable"
         },
         {
+            "name": "Symbol",
+            "scope": "constant.other.symbol",
+            "foreground": "var(yellow)"
+        },
+        {
             "name": "Keyword",
             "scope": "keyword",
             "foreground": "var(red)",

--- a/Catppuccin Latte.sublime-color-scheme
+++ b/Catppuccin Latte.sublime-color-scheme
@@ -104,6 +104,11 @@
             "scope": "variable"
         },
         {
+            "name": "Symbol",
+            "scope": "constant.other.symbol",
+            "foreground": "var(yellow)"
+        },
+        {
             "name": "Keyword",
             "scope": "keyword",
             "foreground": "var(red)",

--- a/Catppuccin Macchiato.sublime-color-scheme
+++ b/Catppuccin Macchiato.sublime-color-scheme
@@ -104,6 +104,11 @@
             "scope": "variable"
         },
         {
+            "name": "Symbol",
+            "scope": "constant.other.symbol",
+            "foreground": "var(yellow)"
+        },
+        {
             "name": "Keyword",
             "scope": "keyword",
             "foreground": "var(red)",

--- a/Catppuccin Mocha.sublime-color-scheme
+++ b/Catppuccin Mocha.sublime-color-scheme
@@ -100,6 +100,11 @@
             "font_style": ""
         },
         {
+            "name": "Symbol",
+            "scope": "constant.other.symbol",
+            "foreground": "var(yellow)"
+        },
+        {
             "name": "Variable",
             "scope": "variable"
         },


### PR DESCRIPTION
Ruby makes extensive use of Symbols, which are scoped as `"constant.other.symbol.ruby"`. Currently these are unstyled. This PR adds a rule to style them. I went with yellow since symbols are styled yellow in `irb` (Ruby's REPL).

Before:
<img width="525" alt="Pasted Graphic" src="https://github.com/catppuccin/sublime-text/assets/19734415/28154542-5d57-49aa-8bf0-10768a9c8606">

After:
<img width="554" alt="table string check_solution" src="https://github.com/catppuccin/sublime-text/assets/19734415/f8538e4e-98dc-4ea8-ab71-ce00b412e35d">

