### PR TITLE
Fix line highlight

### DIFF
--- a/Catppuccin Frappe.sublime-color-scheme
+++ b/Catppuccin Frappe.sublime-color-scheme
@@ -33,7 +33,7 @@
         "invisibles": "var(subtext0)",
         "gutter_foreground": "var(overlay2)",
         "gutter_foreground_highlight": "var(green)",
-        "line_highlight": "var(base)",
+        "line_highlight": "color(var(text) alpha(0.07))",
         "selection": "color(var(overlay1) alpha(0.4))",
         "selection_border": "var(base)",
         "active_guide": "color(var(peach) alpha(0.5))",

--- a/Catppuccin Latte.sublime-color-scheme
+++ b/Catppuccin Latte.sublime-color-scheme
@@ -33,7 +33,7 @@
         "invisibles": "var(subtext0)",
         "gutter_foreground": "var(overlay2)",
         "gutter_foreground_highlight": "var(green)",
-        "line_highlight": "var(base)",
+        "line_highlight": "color(var(text) alpha(0.07))",
         "selection": "color(var(overlay1) alpha(0.4))",
         "selection_border": "var(base)",
         "active_guide": "color(var(peach) alpha(0.5))",

--- a/Catppuccin Macchiato.sublime-color-scheme
+++ b/Catppuccin Macchiato.sublime-color-scheme
@@ -33,7 +33,7 @@
         "invisibles": "var(subtext0)",
         "gutter_foreground": "var(overlay2)",
         "gutter_foreground_highlight": "var(green)",
-        "line_highlight": "var(base)",
+        "line_highlight": "color(var(text) alpha(0.07))",
         "selection": "color(var(overlay1) alpha(0.4))",
         "selection_border": "var(base)",
         "active_guide": "color(var(peach) alpha(0.5))",

--- a/Catppuccin Mocha.sublime-color-scheme
+++ b/Catppuccin Mocha.sublime-color-scheme
@@ -33,7 +33,7 @@
         "invisibles": "var(subtext0)",
         "gutter_foreground": "var(overlay2)",
         "gutter_foreground_highlight": "var(green)",
-        "line_highlight": "var(base)",
+        "line_highlight": "color(var(text) alpha(0.07))",
         "selection": "color(var(overlay1) alpha(0.4))",
         "selection_border": "var(base)",
         "active_guide": "color(var(peach) alpha(0.5))",


### PR DESCRIPTION
Before the line highlight was the same color as the background. (Closes #13)

Before:
<img width="607" alt="before_highlight_line" src="https://github.com/catppuccin/sublime-text/assets/19734415/46c79760-d52e-4da1-9f70-cf200a99509b">

After:
<img width="614" alt="Screenshot 2024-02-29 at 10 17 09 PM" src="https://github.com/catppuccin/sublime-text/assets/19734415/7cba6225-8ed8-4a84-a4d5-5d483790c1a6">

This matches VS Code.
