### PR TITLE
Update invisibles/whitespace color to be much more subtle

### DIFF
--- a/Catppuccin Frappe.sublime-color-scheme
+++ b/Catppuccin Frappe.sublime-color-scheme
@@ -30,7 +30,7 @@
         "foreground": "var(text)",
         "background": "var(base)",
         "caret": "var(subtext1)",
-        "invisibles": "var(subtext0)",
+        "invisibles": "color(var(overlay2) alpha(0.4))",
         "gutter_foreground": "var(overlay2)",
         "gutter_foreground_highlight": "var(green)",
         "line_highlight": "var(base)",

--- a/Catppuccin Latte.sublime-color-scheme
+++ b/Catppuccin Latte.sublime-color-scheme
@@ -30,7 +30,7 @@
         "foreground": "var(text)",
         "background": "var(base)",
         "caret": "var(subtext1)",
-        "invisibles": "var(subtext0)",
+        "invisibles": "color(var(overlay2) alpha(0.4))",
         "gutter_foreground": "var(overlay2)",
         "gutter_foreground_highlight": "var(green)",
         "line_highlight": "var(base)",

--- a/Catppuccin Macchiato.sublime-color-scheme
+++ b/Catppuccin Macchiato.sublime-color-scheme
@@ -30,7 +30,7 @@
         "foreground": "var(text)",
         "background": "var(base)",
         "caret": "var(subtext1)",
-        "invisibles": "var(subtext0)",
+        "invisibles": "color(var(overlay2) alpha(0.4))",
         "gutter_foreground": "var(overlay2)",
         "gutter_foreground_highlight": "var(green)",
         "line_highlight": "var(base)",

--- a/Catppuccin Mocha.sublime-color-scheme
+++ b/Catppuccin Mocha.sublime-color-scheme
@@ -30,7 +30,7 @@
         "foreground": "var(text)",
         "background": "var(base)",
         "caret": "var(subtext1)",
-        "invisibles": "var(subtext0)",
+        "invisibles": "color(var(overlay2) alpha(0.4))",
         "gutter_foreground": "var(overlay2)",
         "gutter_foreground_highlight": "var(green)",
         "line_highlight": "var(base)",


### PR DESCRIPTION
Before:
<img width="641" alt="Screenshot 2024-02-29 at 11 05 52 PM" src="https://github.com/catppuccin/sublime-text/assets/19734415/c15c408b-afc3-4633-aa24-6e505239163c">

After:
<img width="586" alt="Screenshot 2024-02-29 at 11 05 44 PM" src="https://github.com/catppuccin/sublime-text/assets/19734415/788df14c-2c56-48a7-acab-5e903114bbf0">

This matches VS Code's editorWhitespace.foreground rule.
=> https://github.com/catppuccin/vscode/blob/main/packages/catppuccin-vsc/src/theme/uiColors.ts#L199