### PR TITLE
ci(check-pr): use `catppuccin/setup-whiskers`

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -9,15 +9,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: "Install Whiskers"
-      # Ideally this would pull the latest whiskers version
-        run: |
-          curl -fsSL https://github.com/catppuccin/toolbox/releases/download/whiskers-v2.2.0/whiskers-x86_64-unknown-linux-gnu -o $RUNNER_TEMP/whiskers
-          chmod +x $RUNNER_TEMP/whiskers
-          echo $RUNNER_TEMP >> $GITHUB_PATH
-
       - name: "Checkout"
         uses: actions/checkout@v4
+
+      - name: "Install Whiskers"
+        uses: catppuccin/setup-whiskers@v1
+        with:
+          whiskers-version: 2.2.0
 
       - name: "Check"
         run: whiskers sublime-color-scheme.tera --check


### PR DESCRIPTION
This PR updates the CI to use the new catppuccin/setup-whiskers GitHub action.
Renovate will ensure that version in this yaml file and the tera file are updated in #31 once this PR is merged.