### PR TITLE
Use yellow for namespaces, like classes

### DIFF
--- a/build/Catppuccin Frappe.sublime-color-scheme
+++ b/build/Catppuccin Frappe.sublime-color-scheme
@@ -217,7 +217,7 @@
         {
             "name": "Storage type namespace",
             "scope": "entity.name.namespace, meta.path",
-            "foreground": "var(text)",
+            "foreground": "var(yellow)",
             "font_style": "italic"
         },
         {

--- a/build/Catppuccin Latte.sublime-color-scheme
+++ b/build/Catppuccin Latte.sublime-color-scheme
@@ -217,7 +217,7 @@
         {
             "name": "Storage type namespace",
             "scope": "entity.name.namespace, meta.path",
-            "foreground": "var(text)",
+            "foreground": "var(yellow)",
             "font_style": "italic"
         },
         {

--- a/build/Catppuccin Macchiato.sublime-color-scheme
+++ b/build/Catppuccin Macchiato.sublime-color-scheme
@@ -217,7 +217,7 @@
         {
             "name": "Storage type namespace",
             "scope": "entity.name.namespace, meta.path",
-            "foreground": "var(text)",
+            "foreground": "var(yellow)",
             "font_style": "italic"
         },
         {

--- a/build/Catppuccin Mocha.sublime-color-scheme
+++ b/build/Catppuccin Mocha.sublime-color-scheme
@@ -217,7 +217,7 @@
         {
             "name": "Storage type namespace",
             "scope": "entity.name.namespace, meta.path",
-            "foreground": "var(text)",
+            "foreground": "var(yellow)",
             "font_style": "italic"
         },
         {

--- a/sublime-color-scheme.tera
+++ b/sublime-color-scheme.tera
@@ -224,7 +224,7 @@ whiskers:
         {
             "name": "Storage type namespace",
             "scope": "entity.name.namespace, meta.path",
-            "foreground": "var(text)",
+            "foreground": "var(yellow)",
             "font_style": "italic"
         },
         {


### PR DESCRIPTION
This change is weird, doesn't seem intentional. For example, in Ruby it's common to do
```ruby
module MyModule
  class MyClass
    ...
  end
end
```
and `MyModule` is scoped as `entity.name.namespace`. Previous this was colored the same as the class declaration. VSCode scopes this as `entity.name.type.module.ruby` and colors it yellow, same as classes. Of course, the style guide doesn't say anything about namespaces or modules.

Before:
<img width="328" alt="image" src="https://github.com/user-attachments/assets/03a28273-00ac-4117-83be-e4be5577fd91" />

After:
<img width="302" alt="image" src="https://github.com/user-attachments/assets/8d5b342c-f63e-443c-b875-a11388509ff1" />

Closes #35